### PR TITLE
v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rasterizeddb_core"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "ahash",
  "byteorder",

--- a/rasterizeddb_core/Cargo.toml
+++ b/rasterizeddb_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rasterizeddb_core"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 repository = "https://github.com/milen-denev/rasterizeddb"
 license = "GPL-3.0-only"

--- a/rasterizeddb_core/src/core/column.rs
+++ b/rasterizeddb_core/src/core/column.rs
@@ -132,6 +132,12 @@ impl Column {
                     buffer.write_all(string_value.as_bytes()).unwrap();
                     Ok(buffer)
                 },
+                "&alloc::string::String" => {
+                    let mut buffer: Vec<u8> = Vec::new();
+                    let string_value = str::parse::<String>(value.as_ref()).unwrap();
+                    buffer.write_all(string_value.as_bytes()).unwrap();
+                    Ok(buffer)
+                },
                 "&str" => {
                     let mut buffer: Vec<u8> = Vec::new();
                     let string_value = str::parse::<String>(value.as_ref()).unwrap();
@@ -184,6 +190,8 @@ impl Column {
             } else if value_type == "char" {
                 DbType::CHAR
             } else if value_type == "alloc::string::String" {
+                DbType::STRING
+            } else if value_type == "&alloc::string::String" {
                 DbType::STRING
             } else if value_type == "&str" {
                 DbType::STRING

--- a/rasterizeddb_core/src/core/helpers.rs
+++ b/rasterizeddb_core/src/core/helpers.rs
@@ -292,14 +292,13 @@ pub(crate) fn add_in_memory_index(
     if *current_chunk_size > CHUNK_SIZE {
         if let Some(file_chunks_indexes) = in_memory_index.as_mut() {
             let entry = FileChunk {
-                current_file_position: file_position,
+                current_file_position: file_position - *current_chunk_size as u64,
                 chunk_size: *current_chunk_size,
                 next_row_id: current_id
             };
             file_chunks_indexes.push(entry);
         } else {
             let mut chunks_vec: Vec<FileChunk> = Vec::default();
-
             let first_entry = FileChunk {
                 current_file_position: HEADER_SIZE as u64,
                 chunk_size: *current_chunk_size,
@@ -315,7 +314,6 @@ pub(crate) fn add_in_memory_index(
 }
 
 pub(crate) fn add_last_in_memory_index(
-    current_chunk_size: u32,
     file_position: u64,
     file_length: u64,
     in_memory_index: &mut Option<Vec<FileChunk>>) {
@@ -324,7 +322,7 @@ pub(crate) fn add_last_in_memory_index(
         if let Some(file_chunks_indexes) = in_memory_index.as_mut() {
             let entry = FileChunk {
                 current_file_position: file_position,
-                chunk_size: current_chunk_size,
+                chunk_size: file_length as u32 - file_position as u32,
                 next_row_id: 0
             };
             file_chunks_indexes.push(entry);
@@ -333,7 +331,7 @@ pub(crate) fn add_last_in_memory_index(
 
             let first_entry = FileChunk {
                 current_file_position: HEADER_SIZE as u64,
-                chunk_size: current_chunk_size,
+                chunk_size: file_length as u32 - file_position as u32,
                 next_row_id: 0
             };
             

--- a/rasterizeddb_core/src/core/row.rs
+++ b/rasterizeddb_core/src/core/row.rs
@@ -6,6 +6,6 @@ pub struct Row {
 }
 
 #[derive(Debug)]
-pub struct InsertRow {
+pub struct InsertOrUpdateRow {
     pub columns_data: Vec<u8>
 }

--- a/rasterizeddb_core/src/core/support_types.rs
+++ b/rasterizeddb_core/src/core/support_types.rs
@@ -8,7 +8,7 @@ pub struct RowPrefetchResult {
     pub length: u32
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct FileChunk {
     pub current_file_position: u64,
     pub chunk_size: u32,

--- a/rasterizeddb_core/src/lib.rs
+++ b/rasterizeddb_core/src/lib.rs
@@ -48,6 +48,10 @@ pub(crate) static POSITIONS_CACHE: Lazy<Cache<u64, Vec<(u64, u32)>, RandomState>
 /// columns_buffer.append(&mut c2.into_vec().unwrap());
 /// columns_buffer.append(&mut c3.into_vec().unwrap());
 /// 
+/// let insert_row = InsertOrUpdateRow {
+///    columns_data: columns_buffer
+/// };
+/// 
 /// table.insert_row(insert_row).await;
 /// ```
 /// #### Build in-memory file indexes
@@ -77,6 +81,14 @@ pub(crate) static POSITIONS_CACHE: Lazy<Cache<u64, Vec<(u64, u32)>, RandomState>
 /// 
 /// // Uses cache: If the same query is repeated, the time to retrieve a row should be in the single-digit range.
 /// let row_by_query = table.first_or_default_by_query(query_evaluation).await.unwrap().unwrap();
+/// ```
+/// #### Update a row
+/// ```rust
+/// let update_row = InsertOrUpdateRow {
+///     columns_data: columns_buffer_update // Same as insert_row
+/// };
+/// 
+/// table.update_row_by_id(3, update_row).await;
 /// ```
 /// 
 /// #### Delete a row

--- a/rasterizeddb_core/src/main.rs
+++ b/rasterizeddb_core/src/main.rs
@@ -2,7 +2,10 @@ use std::io::stdin;
 
 use rasterizeddb_core::{
     core::{
-        column::Column, row::InsertRow, storage_providers::{file_sync::LocalStorageProvider, memory::MemoryStorageProvider}, table::Table
+        column::Column, 
+        row::InsertOrUpdateRow, 
+        storage_providers::{file_sync::LocalStorageProvider, memory::MemoryStorageProvider}, 
+        table::Table
     }, rql::parser::parse_rql
 };
 
@@ -13,7 +16,7 @@ use std::fs::remove_file;
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_BACKTRACE","0");
 
-    //_ = remove_file("C:\\Users\\mspc6\\OneDrive\\Professional\\Desktop\\database.db");
+    _ = remove_file("C:\\Users\\mspc6\\OneDrive\\Professional\\Desktop\\database.db");
 
     let io_sync = LocalStorageProvider::new(
         "C:\\Users\\mspc6\\OneDrive\\Professional\\Desktop",
@@ -24,63 +27,96 @@ async fn main() -> std::io::Result<()> {
 
     let mut table = Table::init(io_sync, false, false).unwrap();
 
-    // for i in 0..100_000 {
-    //     if i == 99_990 {
-    //         let mut c1 = Column::new(1000).unwrap();
-    //         let mut c2 = Column::new(i * -1).unwrap();
-    //         let mut c3 = Column::new("This is awesome 2.").unwrap();
+    for i in 0..5 {
+        if i == 3 {
+            let mut c1 = Column::new(1000).unwrap();
+            let mut c2 = Column::new(i * -1).unwrap();
+            //let mut c3 = Column::new("This is awesome 2.").unwrap();
     
-    //         let mut columns_buffer: Vec<u8> = Vec::with_capacity(
-    //             c1.len() + 
-    //             c2.len() +
-    //             c3.len() 
-    //         );
+            let mut columns_buffer: Vec<u8> = Vec::with_capacity(
+                c1.len() + 
+                c2.len() //+
+                //c3.len() 
+            );
         
-    //         columns_buffer.append(&mut c1.into_vec().unwrap());
-    //         columns_buffer.append(&mut c2.into_vec().unwrap());
-    //         columns_buffer.append(&mut c3.into_vec().unwrap());
+            columns_buffer.append(&mut c1.into_vec().unwrap());
+            columns_buffer.append(&mut c2.into_vec().unwrap());
+            //columns_buffer.append(&mut c3.into_vec().unwrap());
         
-    //         let insert_row = InsertRow {
-    //             columns_data: columns_buffer
-    //         };
+            let insert_row = InsertOrUpdateRow {
+                columns_data: columns_buffer
+            };
         
-    //         table.insert_row(insert_row).await;
-    //     } else {
-    //         let mut c1 = Column::new(i).unwrap();
-    //         let mut c2 = Column::new(i * -1).unwrap();
-    //         let mut c3 = Column::new("This is also awesome.").unwrap();
+            table.insert_row(insert_row).await;
+        } else {
+            let mut c1 = Column::new(i).unwrap();
+            let mut c2 = Column::new(i * -1).unwrap();
+            //let mut c3 = Column::new("This is also awesome.").unwrap();
     
-    //         let mut columns_buffer: Vec<u8> = Vec::with_capacity(
-    //             c1.len() + 
-    //             c2.len() +
-    //             c3.len() 
-    //         );
+            let mut columns_buffer: Vec<u8> = Vec::with_capacity(
+                c1.len() + 
+                c2.len() //+
+                //c3.len() 
+            );
         
-    //         columns_buffer.append(&mut c1.into_vec().unwrap());
-    //         columns_buffer.append(&mut c2.into_vec().unwrap());
-    //         columns_buffer.append(&mut c3.into_vec().unwrap());
+            columns_buffer.append(&mut c1.into_vec().unwrap());
+            columns_buffer.append(&mut c2.into_vec().unwrap());
+            //columns_buffer.append(&mut c3.into_vec().unwrap());
         
-    //         let insert_row = InsertRow {
-    //             columns_data: columns_buffer
-    //         };
+            let insert_row = InsertOrUpdateRow {
+                columns_data: columns_buffer
+            };
         
-    //         table.insert_row(insert_row).await;
-    //     }
-    // }
+            table.insert_row(insert_row).await;
+        }
+    }
 
     table.rebuild_in_memory_indexes();
 
-    let row = table.first_or_default_by_id(3)?.unwrap();
+    let row = table.first_or_default_by_id(5)?.unwrap();
 
-    for column in Column::from_buffer(&row.columns_data).unwrap() {
-        println!("{}", column.into_value());
-    }
+    // for column in Column::from_buffer(&row.columns_data).unwrap() {
+    //     println!("{}", column.into_value());
+    // }
+
+    // UPDATE ROW(3)
+
+    let x = 48;
+
+    let mut c1_update = Column::new(21).unwrap();
+    let mut c2_update = Column::new(x * -1).unwrap();
+    let large_string = "A".repeat(1024);
+    let mut c3_update = Column::new(&large_string).unwrap();
+
+    let mut columns_buffer_update: Vec<u8> = Vec::with_capacity(
+        c1_update.len() + 
+        c2_update.len() +
+        c3_update.len() 
+    );
+
+    columns_buffer_update.append(&mut c1_update.into_vec().unwrap());
+    columns_buffer_update.append(&mut c2_update.into_vec().unwrap());
+    columns_buffer_update.append(&mut c3_update.into_vec().unwrap());
+
+    let update_row = InsertOrUpdateRow {
+        columns_data: columns_buffer_update
+    };
+
+    table.update_row_by_id(3, update_row).await;
+
+    // END UPDATE ROW(3)
+
+    let row = table.first_or_default_by_id(6)?.unwrap();
+
+    // for column in Column::from_buffer(&row.columns_data).unwrap() {
+    //     println!("{}", column.into_value());
+    // }
 
     let row = table.first_or_default_by_column(0, 1000)?.unwrap();
 
-    for column in Column::from_buffer(&row.columns_data).unwrap() {
-        println!("{}", column.into_value());
-    }
+    // for column in Column::from_buffer(&row.columns_data).unwrap() {
+    //     println!("{}", column.into_value());
+    // }
 
     let mut stopwatch = Stopwatch::new();
 
@@ -89,7 +125,7 @@ async fn main() -> std::io::Result<()> {
         let query_evaluation = parse_rql(&format!(r#"
             BEGIN
             SELECT FROM NAME_DOESNT_MATTER_FOR_NOW
-            WHERE COL(2) = 'This is awesome 2.' 
+            WHERE COL(2) = '{large_string}' 
             END
         "#)).unwrap();
 

--- a/rasterizeddb_core/tests/table_tests.rs
+++ b/rasterizeddb_core/tests/table_tests.rs
@@ -3,7 +3,7 @@ use tokio::runtime;
 
 use rasterizeddb_core::core::{
     column::Column, 
-    row::InsertRow, 
+    row::InsertOrUpdateRow, 
     storage_providers::{file_sync::LocalStorageProvider, memory::MemoryStorageProvider}, 
     table::Table
 };
@@ -37,7 +37,7 @@ pub fn rebuild_indexes_file() {
                 columns_buffer.append(&mut c2.into_vec().unwrap());
                 columns_buffer.append(&mut c3.into_vec().unwrap());
             
-                let insert_row = InsertRow {
+                let insert_row = InsertOrUpdateRow {
                     columns_data: columns_buffer
                 };
             
@@ -57,7 +57,7 @@ pub fn rebuild_indexes_file() {
                 columns_buffer.append(&mut c2.into_vec().unwrap());
                 columns_buffer.append(&mut c3.into_vec().unwrap());
             
-                let insert_row = InsertRow {
+                let insert_row = InsertOrUpdateRow {
                     columns_data: columns_buffer
                 };
             
@@ -93,7 +93,7 @@ pub fn rebuild_indexes_memory() {
                 columns_buffer.append(&mut c2.into_vec().unwrap());
                 columns_buffer.append(&mut c3.into_vec().unwrap());
             
-                let insert_row = InsertRow {
+                let insert_row = InsertOrUpdateRow {
                     columns_data: columns_buffer
                 };
             
@@ -113,7 +113,7 @@ pub fn rebuild_indexes_memory() {
                 columns_buffer.append(&mut c2.into_vec().unwrap());
                 columns_buffer.append(&mut c3.into_vec().unwrap());
             
-                let insert_row = InsertRow {
+                let insert_row = InsertOrUpdateRow {
                     columns_data: columns_buffer
                 };
             


### PR DESCRIPTION
Make Arc<RwLock<>> the in-memory-index. Remove the last file chunk fetching and make it as being part of the in-memory chunks vector. Added update_row_by_id API. Bug fixes in creating memory index. Updated docs and readme. Fix in column.rs an issue where &alloc::string::String isn't recognized. Renamed `InsertRow` to `InsertOrUpdateRow`.